### PR TITLE
Fix for blocked git protocol

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "esprima": "git://github.com/ariya/esprima.git#harmony",
+    "esprima": "git+https://github.com/ariya/esprima.git#harmony",
     "escodegen": "~1.3.1",
     "ast-types": "~0.3.22"
   },


### PR DESCRIPTION
Some corporate networks block the git protocol. This addition will allow node-degenerator to be installed on those networks. See emissary for example. https://github.com/atom/emissary/blob/master/package.json