### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "esprima": "git+https://github.com/ariya/esprima.git#harmony",
+    "esprima": "~2.3.0",
     "escodegen": "~1.3.1",
     "ast-types": "~0.3.22"
   },


### PR DESCRIPTION
Looks like they pulled the harmony branch, so degenerator no longer installs:

https://github.com/jquery/esprima/tree/harmony