### PR TITLE
turning function into generators only if function uses one of 'names'

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,13 +46,13 @@ function degenerator (jsStr, names) {
   // function in `names`. We also add the names of the functions to the `names` array.
   // We'll iterate several time, as every iteration might add new items to the `names` 
   // array, until no new names we're added in the iteration.
-  let lastNamesLength = 0;
+  var lastNamesLength = 0;
   do {
     lastNamesLength = names.length;
     types.visit(ast, {
       visitFunction: function (path) {
         if (path.node.id) {
-          let shouldDegenerate = false;
+          var shouldDegenerate = false;
           types.visit(path.node, {
             visitCallExpression: function (path) {
               if (checkNames(path.node, names)) {

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ function degenerator (jsStr, names) {
           path.node.generator = true;
 
           // add function name to `names` array
-          if (!names.includes(path.node.id.name)) {
+          if (names.indexOf(path.node.id.name) === -1) {
             names.push(path.node.id.name);
           }
         }

--- a/test/assignment.expected.js
+++ b/test/assignment.expected.js
@@ -1,0 +1,11 @@
+baz = foo;
+var biz = foo;
+function foo() {
+    return 42;
+}
+function* bar() {
+    return yield baz();
+}
+function* bir() {
+    return yield biz();
+}

--- a/test/assignment.js
+++ b/test/assignment.js
@@ -1,0 +1,14 @@
+// foo
+baz = foo;
+var biz = foo;
+function foo () {
+  return 42;
+}
+
+function bar () {
+	return baz();
+}
+
+function bir () {
+	return biz();
+}

--- a/test/partial.expected.js
+++ b/test/partial.expected.js
@@ -7,6 +7,6 @@ function* bar() {
 function* baz() {
     return yield bar();
 }
-function shouldChange() {
+function shouldntChange() {
     return 42;
 }

--- a/test/partial.expected.js
+++ b/test/partial.expected.js
@@ -1,0 +1,12 @@
+function* foo() {
+    return yield baz();
+}
+function* bar() {
+    return yield foo(baz);
+}
+function* baz() {
+    return yield bar();
+}
+function shouldChange() {
+    return 42;
+}

--- a/test/partial.js
+++ b/test/partial.js
@@ -1,0 +1,16 @@
+// foo
+function foo () {
+  return baz();
+}
+
+function bar () {
+  return foo(baz);
+}
+
+function baz () {
+  return bar();
+}
+
+function shouldChange () {
+  return 42;
+}

--- a/test/partial.js
+++ b/test/partial.js
@@ -11,6 +11,6 @@ function baz () {
   return bar();
 }
 
-function shouldChange () {
+function shouldntChange () {
   return 42;
 }


### PR DESCRIPTION
I've recently encountered some code that went through this module (it was a pac file used by pac-resolver). The code had some functions that were used as constructors, but never used any of the passed `names` in their call tree. This caused the degenerated code to crush for using generator function as a constructor.

I know this PR doesn't directly solve the constructor issue, but at least for constructor usage that does not invoke any of the `names` function it should do the trick