### PR TITLE
[security] CVE-2021-23449 - Bumped vm2 to 3.9.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ast-types": "^0.13.2",
     "escodegen": "^1.8.1",
     "esprima": "^4.0.0",
-    "vm2": "^3.9.3"
+    "vm2": "^3.9.5"
   },
   "devDependencies": {
     "@types/escodegen": "^0.0.6",


### PR DESCRIPTION
https://security.snyk.io/vuln/SNYK-JS-VM2-1585918