### PR TITLE
[Security] Bump vm2 to 3.9.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "degenerator",
-  "version": "3.0.22",
+  "version": "3.0.2",
   "description": "Compiles sync functions into async generator functions",
   "main": "dist/src/index",
   "typings": "dist/src/index",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "degenerator",
-  "version": "3.0.2",
+  "version": "3.0.22",
   "description": "Compiles sync functions into async generator functions",
   "main": "dist/src/index",
   "typings": "dist/src/index",
@@ -28,7 +28,7 @@
     "ast-types": "^0.13.2",
     "escodegen": "^1.8.1",
     "esprima": "^4.0.0",
-    "vm2": "^3.9.8"
+    "vm2": "^3.9.11"
   },
   "devDependencies": {
     "@types/escodegen": "^0.0.6",


### PR DESCRIPTION
Fix for Critical alert on Snyk: https://security.snyk.io/vuln/SNYK-JS-VM2-3018201