### PR TITLE
fix(vm2): sandbox escape

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ast-types": "^0.13.2",
     "escodegen": "^1.8.1",
     "esprima": "^4.0.0",
-    "vm2": "^3.9.11"
+    "vm2": "^3.9.15"
   },
   "devDependencies": {
     "@types/escodegen": "^0.0.6",


### PR DESCRIPTION
> vm2 is a sandbox that can run untrusted code with whitelisted Node's built-in modules.

This issue has been reported in [vm2 security advisories](https://github.com/patriksimek/vm2/security/advisories/GHSA-7jxr-cg7f-gpgv) and reported to be fixed in the latest [3.9.15](https://github.com/patriksimek/vm2/releases/tag/3.9.15) release.

This issue bubbled up in the latest `superagent-proxy`'s dependencies, which use pinned version to `degenerator`.