### PR TITLE
updated vm2 to 3.9.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ast-types": "^0.13.2",
     "escodegen": "^1.8.1",
     "esprima": "^4.0.0",
-    "vm2": "^3.9.11"
+    "vm2": "^3.9.16"
   },
   "devDependencies": {
     "@types/escodegen": "^0.0.6",


### PR DESCRIPTION
Updating vm2 to version 3.9.16 to resolve a critical vunlerability CVE-2023-29017 [sandbox escape]